### PR TITLE
add JADX decompiler

### DIFF
--- a/decompiler-cmp.iml
+++ b/decompiler-cmp.iml
@@ -6,10 +6,20 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="Maven: jadx:jadx-cli:0.9.0">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jadx-0.9.0/lib/jadx-cli-0.9.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
     <orderEntry type="module-library">
       <library name="Maven: cli.jd:jd-gui:1.4.1">
         <CLASSES>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,15 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>jadx</groupId>
+            <artifactId>jadx-cli</artifactId>
+            <version>0.9.0</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/lib/jadx-0.9.0/lib/jadx-cli-0.9.0.jar</systemPath>
+        </dependency>
+
         <dependency>
             <groupId>cli.jd</groupId>
             <artifactId>jd-gui</artifactId>

--- a/src/main/java/se/kth/decompiler/DecompilerRegistry.java
+++ b/src/main/java/se/kth/decompiler/DecompilerRegistry.java
@@ -16,5 +16,7 @@ public class DecompilerRegistry {
 		decompilers.put("Dava-3.3.0", new Dava());
 		decompilers.put("JD-GUI-1.4.1", new JDGui());
 		decompilers.put("Jode-1.1.2-pre1", new Jode());
+		decompilers.put("JADX-0.9.0", new JADX());
+
 	}
 }

--- a/src/main/java/se/kth/decompiler/JADX.java
+++ b/src/main/java/se/kth/decompiler/JADX.java
@@ -1,0 +1,34 @@
+package se.kth.decompiler;
+
+import se.kth.Decompiler;
+
+
+import java.io.File;
+
+public class JADX implements Decompiler {
+
+    @Override
+    public boolean decompile(File in, File outDir, String cl) {
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    "./jadx", // build-in script to run the decompiler
+                    "-r", // do not decode resources
+                    "-d", outDir.getAbsolutePath(), // output directory
+                    in.getAbsolutePath() // input file (.dex, .apk, .jar or .class)
+            );
+            pb.directory(new File("lib/jadx-0.9.0/bin"));
+            pb.start();
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println(e.getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "JADX-0.9.0";
+    }
+}

--- a/src/test/java/se/kth/decompiler/JADXTest.java
+++ b/src/test/java/se/kth/decompiler/JADXTest.java
@@ -1,0 +1,25 @@
+package se.kth.decompiler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class JADXTest {
+
+    JADX jadx;
+
+    @Before
+    public void setUp() throws Exception {
+        jadx = new JADX();
+    }
+
+    @Test
+    public void decompile() {
+
+        File in = new File("src/test/resources/DiffImpl.class");
+        File out = new File("src/test/resources/");
+
+        jadx.decompile(in, out, "");
+    }
+}


### PR DESCRIPTION
Add support for [JADX](https://github.com/skylot/jadx) decompiler, an actively maintained tool. The class JADX calls the jadx script located in {basedir}/lib/jadx-0.9.0/bin, wich runs the decompiler via command line arguments.